### PR TITLE
AIMS install issue fix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ android {
         abi {
             enable true
             reset()
-            include 'armeabi-v7a', 'arm64-v8a'
+            include 'armeabi-v7a', 'arm64-v8a', 'x86'
             universalApk true
         }
     }


### PR DESCRIPTION
Adds the x86 architecture to the build.gradle file so that AIMS can install the APK on their x86 emulator